### PR TITLE
Add host connection parameters.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,14 @@ if platform.system() == 'Windows':
         VMWARE_BIN = 'VixAllProducts'
     VMWARE_INC = VMWARE_VIX
     VMWARE_LIB = VMWARE_VIX
-    OS_LIBS = ['ws2_32',   'user32', 
-               'kernel32', 'advapi32', 
+    OS_LIBS = ['ws2_32',   'user32',
+               'kernel32', 'advapi32',
                'ole32',    'oleaut32',
                'shell32']
 else:
     # Linux
-    VMWARE_INC = VMWARE_VIX + 'include'
-    VMWARE_LIB = VMWARE_VIX + 'lib'
+    VMWARE_INC = '/usr/include/vmware-vix'
+    VMWARE_LIB = '/usr/lib/vmware-vix'
     VMWARE_BIN = 'vixAllProducts'
     OS_LIBS = []
 

--- a/vixpy.c
+++ b/vixpy.c
@@ -218,13 +218,17 @@ pv_VixHost_Connect(PyObject *self, PyObject *args)
     VixHandle handle = VIX_INVALID_HANDLE;
     VixError err;
     VixServiceProvider hostType = VIX_SERVICEPROVIDER_DEFAULT;
+    char *hostAddr = NULL, *hostUser = NULL, *hostPasswd = NULL;
+
     PyObject *ret = NULL;
 
-    if (!PyArg_ParseTuple(args, "i:VixHost_Connect", &hostType))
+    if (!PyArg_ParseTuple(args, "isss:VixHost_Connect", 
+			   &hostType, &hostAddr, &hostUser, &hostPasswd))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
-    job = VixHost_Connect(VIX_API_VERSION, hostType, NULL, 0, NULL, NULL,
+    job = VixHost_Connect(VIX_API_VERSION, hostType, hostAddr, 0, 
+		    	  hostUser, hostPasswd,
                           0, VIX_INVALID_HANDLE, NULL, NULL);
 
     err = VixJob_Wait(job, VIX_PROPERTY_JOB_RESULT_HANDLE, &handle,

--- a/vixpy.py
+++ b/vixpy.py
@@ -6,8 +6,8 @@ __all__ = ['VixHost',
            'VixError']
 
 class VixHost(object):
-    def __init__(self):
-        self._host = VixHost_Connect(VIX_SERVICEPROVIDER_VMWARE_WORKSTATION)
+    def __init__(self, prov = VIX_SERVICEPROVIDER_VMWARE_WORKSTATION, host = None, user = None, passwd = None):
+        self._host = VixHost_Connect(prov, host, user, passwd)
 
     def __del__(self):
         VixHost_Disconnect(self._host)
@@ -58,7 +58,7 @@ class VixVm(object):
             option = VIX_VMPOWEROP_NORMAL
         VixVM_PowerOff(self._vm, option)
 
-    def reset(self, from_guest=False): 
+    def reset(self, from_guest=False):
         """reset(from_guest=False) -> reset VM"""
         if from_guest:
             option = VIX_VMPOWEROP_FROM_GUEST


### PR DESCRIPTION
VixHost's constructor can now take a hostname,
username and password.

Also fixed the setup.py to work with VIX 1.11
